### PR TITLE
allow arbitrary static fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Please keep in mind the following notes and configuration overrides:
  ES_ENDPOINT: the FQDN of your AWS Elasticsearch Service
  ES_INDEX_PREFIX: the prefix for your indices, which will be suffixed with the date
  ES_REGION: The AWS region, e.g. us-west-1, of your Elasticsearch instance
- ES_ENVIRONMENT: A value to append as the `environment` field in each record.
- ES_DEPLOYMENT: A value to append as the `deployment` field in each record.
+ ES_EXTRA_FIELDS: A json object with static fields appended to each record. E.g. `{"environment":"foo", "deployment":"bar"}`
  ES_BULKSIZE: The number of log lines to bulk index into ES at once. Try 200.
  ```
 

--- a/index.js
+++ b/index.js
@@ -50,8 +50,7 @@ exports.handler = function(event, context) {
         endpoint: process.env.ES_ENDPOINT,
         index: process.env.ES_INDEX_PREFIX + '-' + indexTimestamp, // adds a timestamp to index. Example: alblogs-2015.03.31
         doctype: process.env.ES_DOCTYPE,
-        environment: process.env.ES_ENVIRONMENT,
-        deployment: process.env.ES_DEPLOYMENT,
+        extraFields: JSON.parse(process.env.ES_EXTRA_FIELDS || '{}'),
         maxBulkIndexLines: process.env.ES_BULKSIZE // Max Number of log lines to send per bulk interaction with ES
     };
 
@@ -94,8 +93,7 @@ exports.handler = function(event, context) {
         var logRecord = parse(line.toString());
 
         // Add standard fields to help with searching
-        logRecord['environment'] = esDomain.environment;
-        logRecord['deployment'] = esDomain.deployment;
+        Object.assign(logRecord, esDomain.extraFields);
 
         var serializedRecord = JSON.stringify(logRecord);
         this.push(serializedRecord);


### PR DESCRIPTION
Remove static configuration `ES_ENVIRONMENT` and `ES_DEPLOYMENT` in favor of `ES_EXTRA_FIELDS` with dynamic configuration for static fields.