### PR TITLE
allow custom timestamp field name, e.g. @timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Please keep in mind the following notes and configuration overrides:
  ES_REGION: The AWS region, e.g. us-west-1, of your Elasticsearch instance
  ES_ENVIRONMENT: A value to append as the `environment` field in each record.
  ES_DEPLOYMENT: A value to append as the `deployment` field in each record.
- ES_BULKSIZE: The number of log lines to bulk index into ES at once. Try 200.
+ ES_BULKSIZE: The number of log lines to bulk index into ES at once. Defaults to 200.
+ ES_TIMESTAMP_FIELD_NAME: The field name of event timestamps. Defaults to `timestamp`.
  ```
 
 * The following authorizations are required:

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ exports.handler = function(event, context) {
         doctype: process.env.ES_DOCTYPE,
         environment: process.env.ES_ENVIRONMENT,
         deployment: process.env.ES_DEPLOYMENT,
-        maxBulkIndexLines: process.env.ES_BULKSIZE // Max Number of log lines to send per bulk interaction with ES
+        maxBulkIndexLines: process.env.ES_BULKSIZE || 200, // Max Number of log lines to send per bulk interaction with ES
+        timestampFieldName: process.env.ES_TIMESTAMP_FIELD_NAME || 'timestamp'
     };
 
     /**
@@ -215,7 +216,7 @@ function parse(line) {
     // but are also quote-enclosed for strings containing spaces.
     var field_names = [
         'type',
-        'timestamp',
+        esDomain.timestampFieldName,
         'elb',
         'client',
         'target',


### PR DESCRIPTION
This allows creating shared indexes with other data sources.